### PR TITLE
ci(tidy3d): point FAQ marketing sync at flex main

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,7 +15,7 @@ on:
         required: true
       targetBranch:
         description: target branch
-        default: flexcompute/main
+        default: main
         required: true
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SOURCE_BRANCH: ${{ inputs.sourceBranch || 'develop' }}
-      TARGET_BRANCH: ${{ inputs.targetBranch || 'flexcompute/main' }}
+      TARGET_BRANCH: ${{ inputs.targetBranch || 'main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation
- `flexcompute.com` production now deploys from `flexcompute/flex`'s `main` branch instead of the orphan `flexcompute/main` branch.
- This sync workflow still defaulted generated FAQ marketing content to `flexcompute/main`, so FAQ updates could miss production after the migration.

## Example production URLs
- https://www.flexcompute.com/tidy3d/learning-center/faq/
- https://www.flexcompute.com/tidy3d/learning-center/faq/#what-is-tidy3d
- https://www.flexcompute.com/tidy3d/learning-center/faq/#how-do-i-run-a-simulation-and-access-the-results

## Recent run context
- Most recent marketing sync run succeeded on May 29, 2026: https://github.com/flexcompute/tidy3d-faq/actions/runs/26654444461
- That was a push-triggered run, so it used the workflow fallback `TARGET_BRANCH: ${{ inputs.targetBranch || 'flexcompute/main' }}` from that run's commit.

## Summary
- Change the manual `targetBranch` default from `flexcompute/main` to `main`.
- Change the push-event fallback `TARGET_BRANCH` from `flexcompute/main` to `main`.

## Test plan
- Verified `.github/workflows/sync.yml` no longer references `flexcompute/main`.
- Workflow-only change; not run locally.

Follow-up to https://github.com/flexcompute/flex/pull/14489.

🤖 Generated with [Codex](https://codex.openai.com/)
