### PR TITLE
updating GaussianPulse formula

### DIFF
--- a/_faqs/what-is-the-formula-for-GaussianPulse.md
+++ b/_faqs/what-is-the-formula-for-GaussianPulse.md
@@ -27,7 +27,7 @@ _inputs:
 ---
 The [GaussianPulse](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.GaussianPulse.html){: .color-primary-hover} source time, if the DC component is zeroed out (`remove_dc_component=True`, the default), has the following formula (valid for Tidy3D 2.10 and later):
 
-$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}\,Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
 
 where $t_s = t - t_o t_w$ is the shifted time and the normalization frequency $f_{peak}$ is the frequency at which the pulse spectrum reaches its peak amplitude,
 

--- a/_faqs/what-is-the-formula-for-GaussianPulse.md
+++ b/_faqs/what-is-the-formula-for-GaussianPulse.md
@@ -1,9 +1,10 @@
 ---
 _schema: default
 title: What is the formula for GaussianPulse?
-date: 2025-09-05 17:29:25
+date: 2026-07-16 09:00:00
 enabled: true
 category: Sources
+version: "2.10"
 _inputs:
   title:
     type: text
@@ -24,15 +25,18 @@ _inputs:
         text:
           - key: category_name
 ---
-The GaussianPulse sourcetime, if the DC component is zeroed out, has the following formula:
-<div> </div>
-<center>
-    $(i+\frac{t}{t_w^2\omega_0})Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{(t - t_o*t_w)^2}{2t_w^2}}$
-</center><br>
-<div> </div>
-<div>If the DC component is not zeroed out, the formula is</div><br>
-<center>
-    $iAe^{i\phi}e^{-i\omega_0 t}e^{-\frac{(t - t_o*t_w)^2}{2t_w^2}}$
-</center><br>
-<div>where $A$ is the amplitude, $t_o$ is the time offset, $t_w=\frac{1}{2\pi f_{width}}$ is the width of the pulse in seconds, $\phi$ is the phase shift, and $\omega_0=2\pi f_0$.</div>
-<div>See the code [here](https://docs.flexcompute.com/projects/tidy3d/en/latest/_modules/tidy3d/components/source/time.html#GaussianPulse).</div>
+The [GaussianPulse](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.GaussianPulse.html){: .color-primary-hover} source time, if the DC component is zeroed out (`remove_dc_component=True`, the default), has the following formula (valid for Tidy3D 2.10 and later):
+
+$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}\,Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+
+where $t_s = t - t_o t_w$ is the shifted time and the normalization frequency $f_{peak}$ is the frequency at which the pulse spectrum reaches its peak amplitude,
+
+$$f_{peak}=\frac{f_0+\sqrt{f_0^2+4f_{width}^2}}{2}$$
+
+If the DC component is not zeroed out, the formula is
+
+$$iAe^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+
+where $A$ is the amplitude, $t_o$ is the time offset, $t_w=\frac{1}{2\pi f_{width}}$ is the width of the pulse in seconds, $\phi$ is the phase shift, and $\omega_0=2\pi f_0$.
+
+See the code [here](https://docs.flexcompute.com/projects/tidy3d/en/latest/_modules/tidy3d/components/source/time.html#GaussianPulse){: .color-primary-hover}.

--- a/docs/faq/what-is-the-formula-for-GaussianPulse.md
+++ b/docs/faq/what-is-the-formula-for-GaussianPulse.md
@@ -7,7 +7,7 @@
 
 The [GaussianPulse](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.GaussianPulse.html) source time, if the DC component is zeroed out (`remove_dc_component=True`, the default), has the following formula (valid for Tidy3D 2.10 and later):
 
-$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}\,Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
 
 where $t_s = t - t_o t_w$ is the shifted time and the normalization frequency $f_{peak}$ is the frequency at which the pulse spectrum reaches its peak amplitude,
 

--- a/docs/faq/what-is-the-formula-for-GaussianPulse.md
+++ b/docs/faq/what-is-the-formula-for-GaussianPulse.md
@@ -1,19 +1,22 @@
 # What is the formula for GaussianPulse?
 
-| Date       | Category    |
-|------------|-------------|
-| 2025-09-05 17:29:25 | Sources |
+| Date       | Category    | Version |
+|------------|-------------|---------|
+| 2026-07-16 09:00:00 | Sources | 2.10 |
 
 
-The GaussianPulse sourcetime, if the DC component is zeroed out, has the following formula:
- 
-<center>
-    $(i+\frac{t}{t_w^2\omega_0})Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{(t - t_o*t_w)^2}{2t_w^2}}$
-</center><br>
- 
-If the DC component is not zeroed out, the formula is<br>
-<center>
-    $iAe^{i\phi}e^{-i\omega_0 t}e^{-\frac{(t - t_o*t_w)^2}{2t_w^2}}$
-</center><br>
+The [GaussianPulse](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.GaussianPulse.html) source time, if the DC component is zeroed out (`remove_dc_component=True`, the default), has the following formula (valid for Tidy3D 2.10 and later):
+
+$$\frac{i\omega_0+\frac{t_s}{t_w^2}}{2\pi f_{peak}}\,Ae^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+
+where $t_s = t - t_o t_w$ is the shifted time and the normalization frequency $f_{peak}$ is the frequency at which the pulse spectrum reaches its peak amplitude,
+
+$$f_{peak}=\frac{f_0+\sqrt{f_0^2+4f_{width}^2}}{2}$$
+
+If the DC component is not zeroed out, the formula is
+
+$$iAe^{i\phi}e^{-i\omega_0 t}e^{-\frac{t_s^2}{2t_w^2}}$$
+
 where $A$ is the amplitude, $t_o$ is the time offset, $t_w=\frac{1}{2\pi f_{width}}$ is the width of the pulse in seconds, $\phi$ is the phase shift, and $\omega_0=2\pi f_0$.
+
 See the code [here](https://docs.flexcompute.com/projects/tidy3d/en/latest/_modules/tidy3d/components/source/time.html#GaussianPulse).


### PR DESCRIPTION
Hi guys. We noticed while revising the notebooks that the `GaussianPulse` formula has changed. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only FAQ edits with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **GaussianPulse** FAQ in both `_faqs/` and `docs/faq/` so the published math matches **Tidy3D 2.10+** after the pulse definition changed.
> 
> The zeroed-DC case now uses shifted time \(t_s = t - t_o t_w\), a **\(f_{peak}\)** normalization term in the prefactor, and an explicit formula for \(f_{peak}\). The non-zero-DC case uses \(t_s\) in the Gaussian exponent instead of \((t - t_o t_w)\). Copy also notes `remove_dc_component=True` as the default, scopes validity to 2.10+, and adds API/doc links with cleaner display math (replacing HTML `<center>` blocks).
> 
> Metadata is refreshed: FAQ **date**, a **Version** column in the docs table, and `version: "2.10"` in the CMS front matter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5770b72e59fa7a9c6d9bb57ea6fa6692ca4aee56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->