### PR TITLE
Add FAQ maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This repository is no longer maintained. Tidy3D FAQs are now maintained in the [Tidy3D documentation](https://docs.flexcompute.com/projects/tidy3d/en/latest/faq/docs/index.html).


### PR DESCRIPTION
Adds a public notice that this repository is no longer maintained and links to the current Tidy3D FAQ documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no application code, security, or runtime impact.
> 
> **Overview**
> Adds a **README** stating this repo is **no longer maintained** and directing readers to the current Tidy3D FAQ in the [official documentation](https://docs.flexcompute.com/projects/tidy3d/en/latest/faq/docs/index.html).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ec0345a079629e631a526aa633d19cf86bcad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->